### PR TITLE
Switch to Flatfile generic JS sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "~11.2.14",
     "@angular/platform-browser-dynamic": "~11.2.14",
     "@angular/router": "~11.2.14",
-    "@flatfile/angular": "^3.1.0",
+    "@flatfile/sdk": "^1.0.7",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.3"


### PR DESCRIPTION
I would recommend NOT using the Angular adapter b/c it is for our legacy V2 product. The [generic](https://github.com/FlatFilers/sdk) SDK is not opinionated on which FE framework you use (if any) and can be used w/ our new V3 Portal product.